### PR TITLE
Fix/function naming

### DIFF
--- a/cli-args/index.js
+++ b/cli-args/index.js
@@ -13,7 +13,7 @@ const getFeaturesPath = () => {
 }
 const getMarkDownFilePath = () => {
   const args = libs.commandLineArgs(argumentDefinitions)
-  if (!args.markdownFilePath) throw new Error('markDownFilePath argument not provided')
+  if (!args.markdownFilePath) throw new Error('markdownFilePath argument not provided')
   return normalizedPath(args.markdownFilePath)
 }
 const normalizedPath = pathToDir => path.normalize(pathToDir)

--- a/cli-args/index.js
+++ b/cli-args/index.js
@@ -11,7 +11,7 @@ const getFeaturesPath = () => {
   if (!args.featuresPath) throw new Error('featuresPath argument not provided')
   return normalizedPath(args.featuresPath)
 }
-const getMarkDownFilePath = () => {
+const getMarkdownFilePath = () => {
   const args = libs.commandLineArgs(argumentDefinitions)
   if (!args.markdownFilePath) throw new Error('markdownFilePath argument not provided')
   return normalizedPath(args.markdownFilePath)
@@ -20,5 +20,5 @@ const normalizedPath = pathToDir => path.normalize(pathToDir)
 
 module.exports = {
   getFeaturesPath,
-  getMarkDownFilePath
+  getMarkdownFilePath
 }

--- a/tests/cli-args/index.test.js
+++ b/tests/cli-args/index.test.js
@@ -41,12 +41,12 @@ describe(TESTED_MODULE, () => {
     })
   })
   describe('#getMarkDownFilePath', () => {
-    describe('- when markDownFilePath argument is provided', () => {
-      let markDownFilePathArg
+    describe('- when markdownFilePath argument is provided', () => {
+      let markdownFilePathArg
       beforeEach(() => {
-        markDownFilePathArg = 'foo/bar///jar'
+        markdownFilePathArg = 'foo/bar///jar'
         sinon.stub(libs, 'commandLineArgs').returns({
-          markdownFilePath: markDownFilePathArg
+          markdownFilePath: markdownFilePathArg
         })
         sinon.stub(path, 'normalize').returns('normalized-path')
       })
@@ -55,11 +55,11 @@ describe(TESTED_MODULE, () => {
       })
       it('returns the normalized argument value', () => {
         const result = mod.getMarkDownFilePath()
-        expect(path.normalize).to.have.been.calledWith(markDownFilePathArg)
+        expect(path.normalize).to.have.been.calledWith(markdownFilePathArg)
         expect(result).to.equal('normalized-path')
       })
     })
-    describe('- when markDownFilePath argument not provided', () => {
+    describe('- when markdownFilePath argument not provided', () => {
       beforeEach(() => {
         sinon.stub(libs, 'commandLineArgs').returns({
           someOtherPath: 'foobar'
@@ -69,7 +69,7 @@ describe(TESTED_MODULE, () => {
         sinon.restore()
       })
       it('throws error', () => {
-        expect(() => mod.getMarkDownFilePath()).to.throw('markDownFilePath argument not provided')
+        expect(() => mod.getMarkDownFilePath()).to.throw('markdownFilePath argument not provided')
       })
     })
   })

--- a/tests/cli-args/index.test.js
+++ b/tests/cli-args/index.test.js
@@ -40,7 +40,7 @@ describe(TESTED_MODULE, () => {
       })
     })
   })
-  describe('#getMarkDownFilePath', () => {
+  describe('#getMarkdownFilePath', () => {
     describe('- when markdownFilePath argument is provided', () => {
       let markdownFilePathArg
       beforeEach(() => {
@@ -54,7 +54,7 @@ describe(TESTED_MODULE, () => {
         sinon.restore()
       })
       it('returns the normalized argument value', () => {
-        const result = mod.getMarkDownFilePath()
+        const result = mod.getMarkdownFilePath()
         expect(path.normalize).to.have.been.calledWith(markdownFilePathArg)
         expect(result).to.equal('normalized-path')
       })
@@ -69,7 +69,7 @@ describe(TESTED_MODULE, () => {
         sinon.restore()
       })
       it('throws error', () => {
-        expect(() => mod.getMarkDownFilePath()).to.throw('markdownFilePath argument not provided')
+        expect(() => mod.getMarkdownFilePath()).to.throw('markdownFilePath argument not provided')
       })
     })
   })


### PR DESCRIPTION
- fix `getMarkdownFilePath` function naming & error message casing